### PR TITLE
Plutus calculator addition of average golden ticket selector

### DIFF
--- a/src/app/Pages/misc/pages/misc-plutus-new/plutus-new/misc-plutus-new.component.css
+++ b/src/app/Pages/misc/pages/misc-plutus-new/plutus-new/misc-plutus-new.component.css
@@ -62,7 +62,11 @@
     float: left;
 }
 
-.inputWrapper label {
+.goldenTicketWrapper {
+    float: unset;
+}
+
+.inputWrapper label, .secondaryInputWrapper label {
     color: rgb(38, 73, 236);
     font-weight: bold;
     font-size: 20px;
@@ -125,6 +129,10 @@
     margin-right: 12px;
 }
 
+.averageSpendInput {
+    margin-top: 32.5px;
+}
+
 .averageSpendInput:focus, .pluHeldInput:focus {
     outline: none;
 }
@@ -150,6 +158,7 @@ input[type=number] {
     font-weight: bold;
     margin-left: 12px;
     margin-right: 12px;
+    margin-top: 32.5px;
 }
 
 .requiredSubInfo {
@@ -524,6 +533,7 @@ hr {
 
     .promoButton {
         width: 230px;
+        margin-top: 0;
     }
 
     .promoSelectionScreen {

--- a/src/app/Pages/misc/pages/misc-plutus-new/plutus-new/misc-plutus-new.component.html
+++ b/src/app/Pages/misc/pages/misc-plutus-new/plutus-new/misc-plutus-new.component.html
@@ -35,6 +35,14 @@
     <div class="secondaryInputWrapper">
         <input class="averageSpendInput" type="number" min="0" max="20000" placeholder="Enter Average Monthly Spend" [(ngModel)]="averageMonthlySpend" (input)="averageSpendChange($event)"/>
         <button class="promoButton" (click)="togglePromoVisiblity()"><span *ngIf="!showPromotions">Show Promotions </span><span *ngIf="showPromotions">Hide Promotions </span><div [ngClass]="(showPromotions) ? 'arrow-up' : 'arrow-down'"></div></button>
+        <div class="inputLabelWrapper goldenTicketWrapper">
+            <label for="goldenTicketsUsed">Golden tickets (yearly)</label>
+            <ng-select name="goldenTicketsUsed" [searchable]="false" [clearable]="false" [(ngModel)]="selectedGoldenTicketsAmount" (change)="goldenTicketsAmountChange()">
+                <ng-option *ngFor="let r of eligibleTicketsPerYear" [value]="r">
+                    <span>&nbsp;{{ r }}</span>
+                </ng-option>
+             </ng-select>
+        </div>
     </div>
 
     <!-- shows info text if users has a stack or redeem without having a sub -->
@@ -84,7 +92,7 @@
                 <p>Cashback Rewards</p>
                 <p>Perk Rewards</p>
                 <p>x2 Rewards Vouchers ({{selectedStackingTier.doubleRewards}})</p>
-                <p>Golden Tickets ({{selectedStackingTier.goldenTickets}})</p>
+                <p>Golden Tickets (avg {{selectedGoldenTicketsAmount / 12 | number : '1.0-2'}} / max {{selectedStackingTier.goldenTickets}})</p>
                 <p>Monthly CRY</p>
                 <p>Free Payouts ({{selectedStackingTier.freePayouts}})</p>
                 <p>Monthly Value</p>

--- a/src/app/Pages/misc/pages/misc-plutus-new/plutus-new/misc-plutus-new.component.ts
+++ b/src/app/Pages/misc/pages/misc-plutus-new/plutus-new/misc-plutus-new.component.ts
@@ -40,6 +40,8 @@ export class MiscPlutusNewComponent implements OnInit, OnDestroy {
 
   heldPluCount: number;
   averageMonthlySpend: number;
+  selectedGoldenTicketsAmount: number = 0;
+  eligibleTicketsPerYear: number[] = [0];
   currencySymbol: string = "€";
   showSubRequiredMessage: boolean = false;
   showPromotions: boolean = false;
@@ -158,6 +160,10 @@ export class MiscPlutusNewComponent implements OnInit, OnDestroy {
 
     //always run calculate incase the field is cleared
     this.calculate();
+  }
+
+  goldenTicketsAmountChange() {
+    this.calculateGoldenTicketValue();
   }
 
   togglePromoVisiblity() {
@@ -287,13 +293,9 @@ export class MiscPlutusNewComponent implements OnInit, OnDestroy {
       this.selectedStackingTier = this.stackingTiers[this.stackingTiers.length - 1];
       this.selectedStackingTierIndex = this.stackingTiers.length - 1;
     } else {
-        for (let i = 0; i < this.stackingTiers.length; i++) {
-          if (this.stackingTiers[i].pluRequired > this.heldPluCount) {
-            this.selectedStackingTier = this.stackingTiers[i - 1];
-            this.selectedStackingTierIndex = i - 1;
-            break;
-          }
-        }
+      this.selectedStackingTierIndex = this.stackingTiers.findIndex(stackingTier => stackingTier.pluRequired > this.heldPluCount);
+      this.selectedStackingTier = this.stackingTiers[this.selectedStackingTierIndex];
+      this.updateGoldenTicketToggle();
     }
   }
 
@@ -368,12 +370,14 @@ export class MiscPlutusNewComponent implements OnInit, OnDestroy {
     }
   }
 
+  updateGoldenTicketToggle() {
+    this.eligibleTicketsPerYear = Array.from({length: (this.selectedStackingTier.goldenTickets) * 12 + 1}, (x, i) => i);
+    this.selectedGoldenTicketsAmount = this.selectedStackingTier.goldenTickets * 12;
+    this.calculateGoldenTicketValue();
+  }
+
   calculateGoldenTicketValue() {
-    if (this.currencySymbol === "€") {
-      this.goldenTicketReferralsValue = this.selectedStackingTier.goldenTickets * 20 * this.tetherPrice.eur;
-    } else {
-      this.goldenTicketReferralsValue = this.selectedStackingTier.goldenTickets * 20 * this.tetherPrice.gbp;
-    }
+    this.goldenTicketReferralsValue = this.selectedGoldenTicketsAmount * 20 / 12;
   }
 
   calculateFreePayoutValue() {


### PR DESCRIPTION
I propose to add a selector for the golden ticket to get a more realistic result depending on an average golden ticket used per year.
- It is capped with the default value computed previously * 12 months
- It is by default set to the maximum to get no regression compared to previous version
- Adding an average displayed in the monthly golden ticket
- Simplified code for computation of this.selectedStackingTier
- Updated golden ticket value to remove the currency multiplication because the reward is 20€/20£

By default:
<img width="819" alt="image" src="https://github.com/user-attachments/assets/aab32161-56d1-4e20-a9bc-d263d96500b1">
After updating PLU Stack 500:
<img width="816" alt="image" src="https://github.com/user-attachments/assets/fddb134c-fae5-4156-867c-c8baaa839f2d">
<img width="267" alt="image" src="https://github.com/user-attachments/assets/fdce52a2-a3de-43e6-a8ec-ac4c5d6681d2">
By default in recap:
<img width="769" alt="image" src="https://github.com/user-attachments/assets/aad15094-704e-43cf-8add-c61fa593a2ec">
If picking 20 per year for eg:
<img width="781" alt="image" src="https://github.com/user-attachments/assets/3c979f24-463b-4212-a6f6-dc6caf3d586d">
